### PR TITLE
Environment is deprecated for docker stacks

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -317,7 +317,7 @@ func (c *Client) FindStackByName(stackName, environment string) (*Stack, error) 
 	stacks, err := c.StackList()
 
 	for _, b := range stacks {
-		if (strings.ToLower(b.Name) == strings.ToLower(stackName)) && (environment == "" || environment == b.Environment) {
+		if (strings.ToLower(b.Name) == strings.ToLower(stackName)) && (environment == "" || b.Environment == "" || environment == b.Environment) {
 			return &b, err
 		}
 	}


### PR DESCRIPTION
We need to check if the environment is deprecated for this stack. We should also remove the environment flag from the stack creation or make it optional (it is always requested atm)