### PR TITLE
Formation Bundle (#20)

### DIFF
--- a/formation.go
+++ b/formation.go
@@ -13,6 +13,7 @@ type Formation struct {
 	StencilGroups []StencilGroup `json:"stencil_groups"`
 	BaseTemplate  BaseTemplate   `json:"base_template"`
 	Policies      []Policy       `json:"policies"`
+	HelmReleses   []HelmRelease  `json:"helm_releases"`
 	CreatedAt     time.Time      `json:"created_at_iso"`
 	UpdatedAt     time.Time      `json:"updated_at_iso"`
 	Tags          []string       `json:"tags"`

--- a/helm-release.go
+++ b/helm-release.go
@@ -1,0 +1,48 @@
+package cloud66
+
+import (
+	"time"
+)
+
+type HelmRelease struct {
+	Uid           string    `json:"uid"`
+	DisplayName   string    `json:"display_name"`
+	ChartName     string    `json:"chart_name"`
+	Version       string    `json:"version"`
+	RepositoryURL string    `json:"repository"`
+	Body          string    `json:"body"`
+	CreatedAt     time.Time `json:"created_at_iso"`
+	UpdatedAt     time.Time `json:"updated_at_iso"`
+}
+
+func (p HelmRelease) String() string {
+	return p.DisplayName
+}
+
+func (c *Client) AddHelmReleases(stackUid string, formationUid string, releases []*HelmRelease, message string) ([]HelmRelease, error) {
+	var releasesRes = make([]HelmRelease, 0)
+	var singleRes *HelmRelease
+	for _, helmRelease := range releases {
+		params := struct {
+			Message     string       `json:"message"`
+			HelmRelease *HelmRelease `json:"helm_release"`
+		}{
+			Message:     message,
+			HelmRelease: helmRelease,
+		}
+		singleRes = nil
+
+		req, err := c.NewRequest("POST", "/stacks/"+stackUid+"/formations/"+formationUid+"/helm_releases.json", params, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		err = c.DoReq(req, &singleRes, nil)
+		if err != nil {
+			return nil, err
+		}
+		releasesRes = append(releasesRes, *singleRes)
+	}
+
+	return releasesRes, nil
+}

--- a/policy.go
+++ b/policy.go
@@ -8,6 +8,7 @@ type Policy struct {
 	Uid       string    `json:"uid"`
 	Name      string    `json:"name"`
 	Selector  string    `json:"selector"`
+	Sequence  int       `json:"sequence"`
 	Body      string    `json:"body"`
 	CreatedAt time.Time `json:"created_at_iso"`
 	UpdatedAt time.Time `json:"updated_at_iso"`
@@ -16,4 +17,32 @@ type Policy struct {
 
 func (p Policy) String() string {
 	return p.Name
+}
+
+func (c *Client) AddPolicies(stackUid string, formationUid string, policies []*Policy, message string) ([]Policy, error) {
+	var policiesRes []Policy = make([]Policy, 0)
+	var singleRes *Policy
+	for _, policy := range policies {
+		params := struct {
+			Message string  `json:"message"`
+			Policy  *Policy `json:"policy"`
+		}{
+			Message: message,
+			Policy:  policy,
+		}
+		singleRes = nil
+
+		req, err := c.NewRequest("POST", "/stacks/"+stackUid+"/formations/"+formationUid+"/policies.json", params, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		err = c.DoReq(req, &singleRes, nil)
+		if err != nil {
+			return nil, err
+		}
+		policiesRes = append(policiesRes, *singleRes)
+	}
+
+	return policiesRes, nil
 }

--- a/stencil.go
+++ b/stencil.go
@@ -35,16 +35,17 @@ func (c *Client) AddStencils(stackUid string, formationUid string, stencils []*S
 
 	var stencilRes []Stencil
 
-	req, err := c.NewRequest("POST", "/stacks/"+stackUid+"/formations/"+formationUid+"/stencils.json", params, nil)
-	if err != nil {
-		return nil, err
-	}
+	if len(stencils) > 0 {
+		req, err := c.NewRequest("POST", "/stacks/"+stackUid+"/formations/"+formationUid+"/stencils.json", params, nil)
+		if err != nil {
+			return nil, err
+		}
 
-	stencilRes = nil
-	err = c.DoReq(req, &stencilRes, nil)
-	if err != nil {
-		return nil, err
+		stencilRes = nil
+		err = c.DoReq(req, &stencilRes, nil)
+		if err != nil {
+			return nil, err
+		}
 	}
-
 	return stencilRes, nil
 }

--- a/stencil_group.go
+++ b/stencil_group.go
@@ -16,3 +16,31 @@ type StencilGroup struct {
 func (s StencilGroup) String() string {
 	return s.Name
 }
+
+func (c *Client) AddStencilGroups(stackUid string, formationUid string, groups []*StencilGroup, message string) ([]StencilGroup, error) {
+	var groupRes = make([]StencilGroup, 0)
+	var singleRes *StencilGroup
+	for _, stencilGroup := range groups {
+		params := struct {
+			Message      string        `json:"message"`
+			StencilGroup *StencilGroup `json:"stencil_group"`
+		}{
+			Message:      message,
+			StencilGroup: stencilGroup,
+		}
+		singleRes = nil
+
+		req, err := c.NewRequest("POST", "/stacks/"+stackUid+"/formations/"+formationUid+"/stencil_groups.json", params, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		err = c.DoReq(req, &singleRes, nil)
+		if err != nil {
+			return nil, err
+		}
+		groupRes = append(groupRes, *singleRes)
+	}
+
+	return groupRes, nil
+}


### PR DESCRIPTION
* Implement a new formation bundle structure.

* Minor name fix

* Added the helm releases to the formation

* Changed the helmRelease and policy methods to make an API requesto for each item and added the Sequence number to the policy object

* Added the configurations argument to the CreateFormationBundle method

* Adjusted the Bundle struct definitions

* Slightly changed the helm release object to reflect central's api

* removed the sequence field from the stencil group struct and created the AddStencilGroup method that call central api

* Added the control on the values file of the helm release

* Added the control on the length of the stencils array to upload. Now the api call is done only if there is at least one stencil

* Added the name of the BTR when downloading the bundle from central