### PR TITLE
Add a `/examples` folder with examples files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea
 /.DS_Store
+/cx.json

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# Cloud66 Go Examples
+
+This is a collection of Go examples that demonstrate how to use the Cloud66 Go SDK.

--- a/examples/cloud/main.go
+++ b/examples/cloud/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/cloud66-oss/cloud66"
+)
+
+func main() {
+	// Create a new cloud66 Go client, this will read the
+	// cx.json token file from the root of the project.
+	client := cloud66.GetClient("cx.json", "", "", cloud66.NewClientConfig("https://app.cloud66.com"))
+
+	// Use client to get a list of clouds.
+	// Error omited for brevity.
+	clouds, _ := client.GetCloudsInfo()
+
+	// Print the list of clouds.
+	for _, cloud := range clouds {
+		fmt.Println(cloud.Name)
+
+		// Print the list of regions.
+		for _, region := range cloud.Regions {
+			fmt.Println("\t", region.Name)
+		}
+	}
+}

--- a/examples/ping/main.go
+++ b/examples/ping/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/cloud66-oss/cloud66"
+)
+
+func main() {
+	// Create a new cloud66 Go client, this will read the
+	// cx.json token file from the root of the project.
+	client := cloud66.GetClient("cx.json", "", "", cloud66.NewClientConfig("https://app.cloud66.com"))
+
+	// Use client to send an unauthorized ping.
+	if err := client.UnauthenticatedPing(); err != nil {
+		fmt.Println("Unauthorized ping failed:", err)
+		return
+	}
+
+	fmt.Println("Unauthorized ping succeeded")
+
+	// Use client to send an authorized ping.
+	if err := client.AuthenticatedPing(); err != nil {
+		fmt.Println("Authorized ping failed:", err)
+		return
+	}
+
+	fmt.Println("Authorized ping succeeded")
+}

--- a/examples/stacks/main.go
+++ b/examples/stacks/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/cloud66-oss/cloud66"
+)
+
+func main() {
+	// Create a new cloud66 Go client, this will read the
+	// cx.json token file from the root of the project.
+	client := cloud66.GetClient("cx.json", "", "", cloud66.NewClientConfig("https://app.cloud66.com"))
+
+	// Use client to get a list of stacks.
+	// Error omited for brevity.
+	stacks, _ := client.StackList()
+
+	// Print the list of stacks.
+	for _, stack := range stacks {
+		fmt.Println(stack.Name)
+	}
+}


### PR DESCRIPTION
This PR adds three examples showing different client usages.

- How to ping via the client to check the health of the client.
- How to get a list of account stacks.
- How to get a list of account clouds.

This is useful since the authorization example that's shown in the `README.md` doesn't work as presented. It shows the usage of the `Authorize` function being called from the cloud66 package as its public function, which cannot be done since the function is a public function on the client.

https://github.com/cloud66-oss/cloud66/blob/a0442984d6b7a4c716481f943f0fee43c8cd8baf/cloud66.go#L290

The `README.md` shows how to get a new client, somewhat, but misses the part about how you need to pass in the client config and add the API's base URL.

https://github.com/cloud66-oss/cloud66/blob/a0442984d6b7a4c716481f943f0fee43c8cd8baf/cloud66.go#L321