### PR TITLE
Add OperationLogs method for v3 operations logs endpoint

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// operation log severity levels — match the server-side LogUtils scale.
+// OperationLogSeverity values mirror the server-side LogUtils scale.
 const (
 	OperationLogSeverityTrace  = 0
 	OperationLogSeverityDebug  = 1
@@ -22,7 +22,7 @@ type OperationLogEntry struct {
 	Severity int `json:"v"`
 	// human-readable log message
 	Message string `json:"m"`
-	// timestamp in ISO 8601 / RFC 3339
+	// timestamp in RFC 3339 (e.g. 2025-01-15T10:00:05Z)
 	Timestamp time.Time `json:"t"`
 	// source operation when nested under a parent; nil for root entries
 	Source *string `json:"s"`
@@ -50,7 +50,7 @@ func (c *Client) OperationLogs(operationUid string, minSeverity *int, includeChi
 
 	var p Pagination
 	var result []OperationLogEntry
-	var pageRes []OperationLogEntry
+	var operationLogRes []OperationLogEntry
 
 	for {
 		req, err := c.NewRequest("GET", "/operations/"+operationUid+"/logs.json", nil, queryStrings)
@@ -58,13 +58,13 @@ func (c *Client) OperationLogs(operationUid string, minSeverity *int, includeChi
 			return nil, err
 		}
 
-		pageRes = nil
-		err = c.DoReq(req, &pageRes, &p)
+		operationLogRes = nil
+		err = c.DoReq(req, &operationLogRes, &p)
 		if err != nil {
 			return nil, err
 		}
 
-		result = append(result, pageRes...)
+		result = append(result, operationLogRes...)
 		// stop when there's no next page (current page == last page)
 		if p.Current < p.Next {
 			queryStrings["page"] = strconv.Itoa(p.Next)

--- a/operation.go
+++ b/operation.go
@@ -1,0 +1,77 @@
+package cloud66
+
+import (
+	"strconv"
+	"time"
+)
+
+// operation log severity levels — match the server-side LogUtils scale.
+const (
+	OperationLogSeverityTrace  = 0
+	OperationLogSeverityDebug  = 1
+	OperationLogSeverityInfo   = 2
+	OperationLogSeverityNotice = 3
+	OperationLogSeverityWarn   = 4
+	OperationLogSeverityError  = 5
+)
+
+// OperationLogEntry is a single log entry returned by the operations logs endpoint.
+// json keys are intentionally terse — they mirror the server's OperationLogEntity shape.
+type OperationLogEntry struct {
+	// severity level (0..5); see OperationLogSeverity* constants
+	Severity int `json:"v"`
+	// human-readable log message
+	Message string `json:"m"`
+	// timestamp in ISO 8601 / RFC 3339
+	Timestamp time.Time `json:"t"`
+	// source operation when nested under a parent; nil for root entries
+	Source *string `json:"s"`
+	// echelon — depth from the root operation (0 = root)
+	Echelon int `json:"e"`
+}
+
+// OperationLogs returns all log entries for the operation identified by its UID.
+// Works for any async operation (deployments, ssl, load balancer, archive/restore, etc.).
+//
+// minSeverity, when non-nil, filters out entries below the given severity (0..5);
+// pass nil for "no filter". includeChildren aggregates logs from child operations.
+// auto-paginates through every page server-side.
+func (c *Client) OperationLogs(operationUid string, minSeverity *int, includeChildren bool) ([]OperationLogEntry, error) {
+	queryStrings := make(map[string]string)
+	queryStrings["page"] = "1"
+	// only set min_severity when caller asked for one — server treats absent as "no filter"
+	if minSeverity != nil {
+		queryStrings["min_severity"] = strconv.Itoa(*minSeverity)
+	}
+	// only set include_children when true; server defaults to false
+	if includeChildren {
+		queryStrings["include_children"] = "true"
+	}
+
+	var p Pagination
+	var result []OperationLogEntry
+	var pageRes []OperationLogEntry
+
+	for {
+		req, err := c.NewRequest("GET", "/operations/"+operationUid+"/logs.json", nil, queryStrings)
+		if err != nil {
+			return nil, err
+		}
+
+		pageRes = nil
+		err = c.DoReq(req, &pageRes, &p)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, pageRes...)
+		// stop when there's no next page (current page == last page)
+		if p.Current < p.Next {
+			queryStrings["page"] = strconv.Itoa(p.Next)
+		} else {
+			break
+		}
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
## Summary

- Adds `Client.OperationLogs(operationUid, minSeverity, includeChildren)` wrapping the new `GET /api/3/operations/:id/logs` endpoint (cloud66/central#7687).
- Works for any async operation looked up by UID — deployments, SSL, load balancer, archive/restore, etc.
- Auto-paginates server-side; returns a single flat slice.
- `minSeverity *int` — `nil` means "no filter" (matches server semantics where the param is absent).
- Adds `OperationLogSeverity{Trace,Debug,Info,Notice,Warn,Error}` constants (0..5) matching the server-side LogUtils scale.
- Adds `OperationLogEntry` with terse JSON keys (`v/m/t/s/e`) mapped to readable Go field names.

Unblocks `cx` so it can consume the new endpoint.