### PR TITLE
Expose OperationUid on OperationLogEntry

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -28,6 +28,9 @@ type OperationLogEntry struct {
 	Source *string `json:"s"`
 	// echelon — depth from the root operation (0 = root)
 	Echelon int `json:"e"`
+	// uid of the child operation that produced the entry; only present when
+	// include_children=true and the entry came from a descendant, nil otherwise
+	OperationUid *string `json:"operation_uid,omitempty"`
 }
 
 // OperationLogs returns all log entries for the operation identified by its UID.


### PR DESCRIPTION
## Summary

- Adds `OperationUid *string` to `OperationLogEntry`, mapping the `operation_uid` JSON key documented in cloud66/central#7689.
- Only relevant when callers set `includeChildren=true`: child-emitted rows carry extra keys (`operation_id`, `operation_uid`, `operation_type`, duplicate `echelon`) on top of the base `v/m/t/s/e` set.
- Of those extras, only `operation_uid` is exposed outward — internal id, type, and the duplicate echelon are intentionally left off the struct.
- `*string` + `omitempty` because the field is absent on root-level entries.