### PR TITLE
expose LogicalBackup on ManagedBackup

### DIFF
--- a/backups.go
+++ b/backups.go
@@ -46,6 +46,9 @@ type ManagedBackup struct {
 	VerifyResult  string    `json:"verify_result"`
 	StoragePath   string    `json:"storage_path"`
 	SkipTables    string    `json:"skip_tables"`
+	// true for logical (text) backups, false for binary/physical backups;
+	// nil when the backup job has been pruned, so the type is unknown
+	LogicalBackup *bool `json:"logical_backup"`
 }
 
 type BackupSegmentIndex struct {


### PR DESCRIPTION
## What

Adds a `LogicalBackup *bool` field to the `ManagedBackup` struct, mapping the `logical_backup` JSON field now returned by the central API.

## Why

`cx backups list` can't currently tell text from binary backups. The type is determined by the backup job's `logical_backup` flag (true = logical/text, false = physical/binary), which central now serializes on the backups index endpoint.

## Notes

- Uses `*bool` rather than `bool` so a pruned backup job (central sends `null`) reads as **unknown** rather than being silently mislabeled as binary. JSON `null` into a plain `bool` is a no-op leaving the zero value `false`.
- Matches the existing `LogicalBackup *bool` field on the create-backup struct in the same file.

Follow-up: bump this dependency in `cx` and render the type column in `backups list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)